### PR TITLE
Make Immutable.js comparison example more idiomatic and readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ const state2 = Immer.produce(state1, draft => {
 // With Immutable.js (and regular objects)
 const immutableState = Immutable.fromJS(state1);
 const state2 = immutableState
-    .setIn(['counters', 0, 'value'], 2)
-    .setIn(['counters', 1, 'value'], 1)
-    .setIn(['metadata', 'lastUpdate'], 1584383011300);
+    .setIn(["counters", 0, "value"], 2)
+    .setIn(["counters", 1, "value"], 1)
+    .setIn(["metadata", "lastUpdate"], 1584383011300);
 ```
 
 ### A Simple Example
@@ -156,12 +156,12 @@ assert(two.b.c === #[2, 3, 4, #[5, 7]]);
 
 #### Does deep path properties syntax support objects?
 
-No, the semantics for deep path propertiess for objects are much more unclear than they are for `Record`, where (because `Records` are immutable) the semantics are much simpler.
+No, the semantics for deep path properties for objects are much less clear than they are for `Record`, where (because `Records` are immutable) the semantics are much simpler.
 
 
 #### What happens if the deep path property does not exist in the value that is spread?
 
-A TypeError is thrown. For example:
+A `TypeError` is thrown. For example:
 
 ```js
 const one = #{ a: #{} };
@@ -183,7 +183,7 @@ To keep things simple and minimal, attempting to use a deep path property where 
 
 #### What happens if a deep path property attempts to set a non-number-like key on a Tuple
 
-A TypeError is thrown. For example:
+A `TypeError` is thrown. For example:
 
 ```js
 const one = #{ a: #[1,2,3] };

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ECMAScript proposal for deep paths properties for [Record literals](https://gith
 
 # Overview
 
-[Record literals](https://github.com/tc39/proposal-record-tuple) sometimes include deeply nested structures, but the syntax for describing them (either as a fresh value, or based on a previous value via spread syntax) can be cumbersome and/or verbose. Deep path properties for `Record` literals provides a solution to this problem, by introducing a new syntax for describing deeply nested structures in a more succient and readable way.
+[Record literals](https://github.com/tc39/proposal-record-tuple) sometimes include deeply nested structures, but the syntax for describing them (either as a fresh value, or based on a previous value via spread syntax) can be cumbersome and/or verbose. Deep path properties for `Record` literals provides a solution to this problem, by introducing a new syntax for describing deeply nested structures in a more succinct and readable way.
 
 ## Examples
 
@@ -34,7 +34,7 @@ const state1 = #{
     ],
     metadata: #{
         lastUpdate: 1584382969000,
-    }
+    },
 };
 
 const state2 = #{
@@ -86,18 +86,10 @@ const state2 = Immer.produce(state1, draft => {
 
 // With Immutable.js (and regular objects)
 const immutableState = Immutable.fromJS(state1);
-const state2 = immutableState.merge({
-    counters: immutableState.get("counters").zipWith(
-        (a, b) => a.merge(b),
-        [
-            { value: 2 },
-   	        { value: 1 },
-            {},
-        ]),
-    metadata: {
-  	    lastUpdate: 1584383011300,
-    },
-});
+const state2 = immutableState
+    .setIn(['counters', 0, 'value'], 2)
+    .setIn(['counters', 1, 'value'], 1)
+    .setIn(['metadata', 'lastUpdate'], 1584383011300);
 ```
 
 ### A Simple Example


### PR DESCRIPTION
the change makes the Immutable.js example far more readable and illustrates a userland syntax that is comparable to the syntax in this proposal. also, the simplified version actually works (a property path can traverse Maps and Lists), as illustrated here: https://codesandbox.io/s/immutable-js-deep-path-properties-example-xqc9y

also:
* fixed typos (“succient” → “succinct”, “propertiess” → “properties”)
* added a trailing comma to the `state1` record in the first example for consistency
* revise the double-negative in “much more unclear” → “much less clear”
* use backticks to render `TypeError` as monospace